### PR TITLE
UAF-6400 - Adding '-DnoReleaseBuild=true' option, as release build cu…

### DIFF
--- a/release-kfs.sh
+++ b/release-kfs.sh
@@ -69,6 +69,6 @@ cd /tmp/repo/kfs
 # Utilize the jgitflow plugin to generate the release for KFS
 # For more information: https://bitbucket.org/atlassian/jgit-flow
 mvn -DskipTests=true jgitflow:release-start -DreleaseVersion=$releaseVersion -DdevelopmentVersion=$developmentVersion \
-    -DscmCommentPrefix="$releaseTicketNumber - " -DdefaultOriginUrl=$kfsRepoUrl && \
+    -DscmCommentPrefix="$releaseTicketNumber - " -DdefaultOriginUrl=$kfsRepoUrl -DnoReleaseBuild=true && \
 mvn -DskipTests=true jgitflow:release-finish -DreleaseVersion=$releaseVersion -DdevelopmentVersion=$developmentVersion \
-    -DscmCommentPrefix="$releaseTicketNumber - " -DdefaultOriginUrl=$kfsRepoUrl
+    -DscmCommentPrefix="$releaseTicketNumber - " -DdefaultOriginUrl=$kfsRepoUrl -DnoReleaseBuild=true


### PR DESCRIPTION
…rrently breaks unnecessarily on JavaDoc strictness which breaks backwards compatibility.